### PR TITLE
fix: function (buildFlattenNodeAttributes) return component Attributes error

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -30,7 +30,7 @@ export class Template extends RecursiveTemplate {
     const component = this.miniComponents[nodeName]
 
     return Object.keys(component)
-      .map(k => `${k}="${k.startsWith('bind') || k.startsWith('on') || k.startsWith('catch') ? component[k] : `{{${component[k].replace('i.', 'item.')}}}`}"`)
+      .map(k => `${k}="${k.startsWith('bind') || k.startsWith('on') || k.startsWith('catch') ? component[k] : `{{${component[k].replace(/i./g, 'item.')}}}`}"`)
       .join(' ') + ' id="{{item.uid||item.sid}}" data-sid="{{item.sid}}"'
   }
 


### PR DESCRIPTION
函数buildFlattenNodeAttributes返回的Attributes有点问题，比如对于`<Input />`组件 ，FlattenNodeAttributes 之前该组件的attrs为：
<img width="530" alt="image" src="https://github.com/NervJS/taro-plugin-platform-kwai/assets/62830430/6ef112cc-67a9-49f4-8ce9-8a064b50a15e">
而map之后属性变成了
<img width="730" alt="image" src="https://github.com/NervJS/taro-plugin-platform-kwai/assets/62830430/61b25c86-934f-4b99-bb62-05755b593c47">，
可以看到input的focus的值变成了`focus="{{item.focus===undefined?!1:i.focus}}"` 而正确的应该是 `focus="{{item.focus===undefined?!1:item.focus}}"`。

所以需要把replace换成replaceAll，自测下来应该没有问题
